### PR TITLE
Fix bug in Distribution2D::tabulateCdf() with CIRCULAR mapping

### DIFF
--- a/lib/rendering/pbr/core/Distribution.cc
+++ b/lib/rendering/pbr/core/Distribution.cc
@@ -551,27 +551,35 @@ Distribution2D::tabulateCdf(Mapping mapping)
     }
 
     case CIRCULAR: {
-        // Weights outside of the maximal inscribed circle are set to black so
-        // we don't (or rarely) sample them.
-        // note: We are slighly pushing out the extents so we don't get full
-        //       black for the edge scanlines.
+        // Set to near-zero the sampling weights of any texels which don't overlap the inscribed circle,
+        // so that we generate almost no samples inside such texels.
+        // TODO: support setting them to exactly zero.
+
         float sclU, ofsU, sclV, ofsV;
         getScaleOffset(-0.5f, float(sizeU) - 0.5f, -1.0f, 1.0f, &sclU, &ofsU);
         getScaleOffset(-0.5f, float(sizeV) - 0.5f, -1.0f, 1.0f, &sclV, &ofsV);
 
+        const float halfTexelU = 2.0f / float(sizeU);
+        const float halfTexelV = 2.0f / float(sizeV);
+
         tbb::parallel_for(tbb::blocked_range<size_type>(0, sizeV, sizeV / sRangeDivider),
                           [&](const tbb::blocked_range<size_type> range) {
             for (size_type y = range.begin(); y < range.end(); ++y) {
-                float t = float(y) * sclV + ofsV;
-                float t2 = t * t;
+                const float tCenter = float(y) * sclV + ofsV;
+                const float tCorner = scene_rdl2::math::abs(tCenter) - halfTexelV;
+                const float t = max(tCorner, 0.0f);
+                const float t2 = t * t;
                 for (size_type x = 0; x < sizeU; ++x) {
-                    float s = float(x) * sclU + ofsU;
+                    const float sCenter = float(x) * sclU + ofsU;
+                    const float sCorner = scene_rdl2::math::abs(sCenter) - halfTexelU;
+                    const float s = max(sCorner, 0.0f);
                     if (s*s + t2 > 1.0f) {
                         setWeight(x, y, sEpsilon);
                     }
                 }
             }
         });
+
         break;
     }
     default: {

--- a/lib/rendering/pbr/core/Distribution.h
+++ b/lib/rendering/pbr/core/Distribution.h
@@ -212,9 +212,9 @@ public:
     enum Mapping {
         NONE,           ///< Undefined / un-initialized
         PLANAR,         ///< Weighted by the image luminance, no-op.
-        CIRCULAR,       ///< Used for disk light texture sampling, pixels outside of 
-                        ///< a maximal inscribed circle are set to black so we don't
-                        ///< sample them.
+        CIRCULAR,       ///< Used for disk light texture sampling, texels outside of 
+                        ///< the inscribed circle have their sampling weights set to
+                        ///< near-zero so we don't sample them.
         HEMISPHERICAL,  ///< Assuming a latlong input, the upper half of image is
                         ///< weighted by math::sin(2pi * v), see (see pbrt section 14.6.5).
                         ///< The bottom half of image is set to zero so it's not


### PR DESCRIPTION
Resolves OpenMoonRay/openmoonray#248
Fixed a bug in textured DiskLights which yielded slightly incorrect sampling and added fireflies.

The extra half texel offset ensures inclusion of all texels which have non-empty intersection with the disk.

Signed-of-by: Jon Lanz <jon.lanz@dreamworks.com>
