### PR TITLE
Fixes integer overflow problem in light stats (#2268)

### DIFF
--- a/lib/rendering/rndr/RenderStatistics.cc
+++ b/lib/rendering/rndr/RenderStatistics.cc
@@ -1299,7 +1299,7 @@ void populateLightStats(std::vector<LightStat>& lightStats, float& totalTime, fl
     int pixelSamplesSqrt = sceneVars.get(scene_rdl2::rdl2::SceneVariables::sPixelSamplesSqrt);
     int numPixels        = sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageWidth) * 
                            sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageHeight);
-    int totalPixelSamples = pixelSamplesSqrt*pixelSamplesSqrt * numPixels;
+    double totalPixelSamples = static_cast<double>(pixelSamplesSqrt)*pixelSamplesSqrt * numPixels;
     
     totalTime = 0.0;
     float totalEfficiency = 0.f;
@@ -1321,9 +1321,10 @@ void populateLightStats(std::vector<LightStat>& lightStats, float& totalTime, fl
         totalEfficiency += lightStat.efficiency;
     }
 
-    avgTimePerLight = totalTime / scene->getLightCount();
-    avgEfficiency = totalEfficiency / scene->getLightCount();
-    avgLightsChosen = pbrStats.getCounter(pbr::STATS_NUM_LIGHTS_CHOSEN) / totalPixelSamples;
+    avgTimePerLight = scene->getLightCount() > 0 ? totalTime / scene->getLightCount() : 0.f;
+    avgEfficiency = scene->getLightCount() > 0 ? totalEfficiency / scene->getLightCount() : 0.f;
+    avgLightsChosen = totalPixelSamples > 0 ? 
+                      pbrStats.getCounter(pbr::STATS_NUM_LIGHTS_CHOSEN) / totalPixelSamples : 0.0;
 }
 
 void RenderStats::logLightStats(const pbr::Statistics& pbrStats, const pbr::Scene* scene,

--- a/lib/rendering/rndr/RenderStatistics.cc
+++ b/lib/rendering/rndr/RenderStatistics.cc
@@ -1336,7 +1336,7 @@ void populateLightStats(std::vector<LightStat>& lightStats, float& totalTime, fl
 
     avgTimePerLight = totalTime / numLights;
     avgEfficiency = totalEfficiency / numLights;
-    avgLightsChosen = static_cast<float>(numLightsChosen / static_cast<float>(totalPixelSamples));
+    avgLightsChosen = numLightsChosen / static_cast<float>(totalPixelSamples);
 }
 
 void RenderStats::logLightStats(const pbr::Statistics& pbrStats, const pbr::Scene* scene,

--- a/lib/rendering/rndr/RenderStatistics.cc
+++ b/lib/rendering/rndr/RenderStatistics.cc
@@ -1297,13 +1297,26 @@ void populateLightStats(std::vector<LightStat>& lightStats, float& totalTime, fl
                         const pbr::Scene* scene, const scene_rdl2::rdl2::SceneVariables& sceneVars)
 {
     int pixelSamplesSqrt = sceneVars.get(scene_rdl2::rdl2::SceneVariables::sPixelSamplesSqrt);
-    int numPixels        = sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageWidth) * 
-                           sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageHeight);
-    double totalPixelSamples = static_cast<double>(pixelSamplesSqrt)*pixelSamplesSqrt * numPixels;
-    
-    totalTime = 0.0;
+    uint32_t numPixels = static_cast<uint32_t>(sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageWidth)) * 
+                         static_cast<uint32_t>(sceneVars.get(scene_rdl2::rdl2::SceneVariables::sImageHeight));
+    int numLights = scene->getLightCount();
+    // Prevent overflow by using uint64_t, since pixelSamplesSqrt and numPixels can be large.
+    uint64_t totalPixelSamples = static_cast<uint64_t>(pixelSamplesSqrt) * pixelSamplesSqrt * numPixels;
+    // Also need to use uint64_t for numLightsChosen, as it will be a multiple of totalPixelSamples
+    uint64_t numLightsChosen = pbrStats.getCounter(pbr::STATS_NUM_LIGHTS_CHOSEN);
+
+    // Initialize return values
+    totalTime = 0.f;
+    avgTimePerLight = 0.f;
+    avgEfficiency = 0.f;
+    avgLightsChosen = 0.f;
+
+    if (numLights == 0 || totalPixelSamples == 0) {
+        return;
+    }
+
     float totalEfficiency = 0.f;
-    for (int i = 0; i < scene->getLightCount(); ++i) {
+    for (int i = 0; i < numLights; ++i) {
         const pbr::Light* light = scene->getLight(i);
 
         // If we haven't taken any samples from the light, don't add it
@@ -1321,10 +1334,9 @@ void populateLightStats(std::vector<LightStat>& lightStats, float& totalTime, fl
         totalEfficiency += lightStat.efficiency;
     }
 
-    avgTimePerLight = scene->getLightCount() > 0 ? totalTime / scene->getLightCount() : 0.f;
-    avgEfficiency = scene->getLightCount() > 0 ? totalEfficiency / scene->getLightCount() : 0.f;
-    avgLightsChosen = totalPixelSamples > 0 ? 
-                      pbrStats.getCounter(pbr::STATS_NUM_LIGHTS_CHOSEN) / totalPixelSamples : 0.0;
+    avgTimePerLight = totalTime / numLights;
+    avgEfficiency = totalEfficiency / numLights;
+    avgLightsChosen = static_cast<float>(numLightsChosen / static_cast<float>(totalPixelSamples));
 }
 
 void RenderStats::logLightStats(const pbr::Statistics& pbrStats, const pbr::Scene* scene,


### PR DESCRIPTION
Resolves OpenMoonRay/openmoonray/issues/249

Fixed moonray_gui crash caused by integer overflow in light stat calculation

Signed-off-by: Jon Lanz <jon.lanz@dreamworks.com>
