### PR TITLE
Extend --print-bsdf to include each lobe's label

### DIFF
--- a/lib/rendering/shading/bsdf/Bsdf.cc
+++ b/lib/rendering/shading/bsdf/Bsdf.cc
@@ -154,7 +154,10 @@ Bsdf::show(const std::string &sceneClass, const std::string &name, std::ostream&
         const BsdfLobe* const lobe = mLobeArray[i];
         if (lobe->getLightSet()) {
             os << "<LightSet> : '" << lobe->getLightSet()->getName() << "'\n";
+        } else {
+            os << "<LightSet> : '<none>'\n";
         }
+        os << "label: " << lobe->getLabel() << "\n";
         lobe->show(os, "");
         os << "\n";
     }

--- a/lib/rendering/shading/ispc/bsdf/Bsdf.ispc
+++ b/lib/rendering/shading/ispc/bsdf/Bsdf.ispc
@@ -58,6 +58,7 @@ Bsdf_show(const varying Bsdf &bsdf,
         } else {
             print("<LightSet> : '<none>'\n");
         }
+        print("label: %\n", lobe->mLabel);
         BsdfLobe_show(lobe, 0);
         print("\n");
     }


### PR DESCRIPTION
Signed-off-by: Jon Lanz <jon.lanz@dreamworks.com>
