### PR TITLE
MOONRAY-5822/MOONRAY-6057 (#2274)

### DIFF
--- a/lib/rendering/shading/bsdf/BsdfIridescence.h
+++ b/lib/rendering/shading/bsdf/BsdfIridescence.h
@@ -25,7 +25,11 @@ namespace {
 
 finline float
 fitInRange(float value, float oldMin, float oldMax, float newMin, float newMax) {
-    return ((newMax - newMin) * (value - oldMin) / (oldMax - oldMin)) + newMin;
+    const float range = oldMax - oldMin;
+    if (scene_rdl2::math::isZero(range)) {
+        return newMin;
+    }
+    return ((newMax - newMin) * (value - oldMin) / range) + newMin;
 }
 
 scene_rdl2::math::Color

--- a/lib/rendering/shading/ispc/BsdfBuilder.ispc
+++ b/lib/rendering/shading/ispc/BsdfBuilder.ispc
@@ -682,7 +682,7 @@ BsdfBuilder_addMirrorBSDF(
     const varying Vec3f adaptedNormal =
         Intersection_adaptNormal(asAnIntersection(*(me.mState)), bsdf.mN);
 
-    if (reflWeight > 0.f) {
+    if (any(reflWeight > 0.f)) {
         refl = (varying BsdfLobe * uniform)
             Arena_alloc(me.mTls->mArena, sizeof(varying MirrorReflectionBsdfLobe));
         MirrorReflectionBsdfLobe_init(
@@ -690,7 +690,7 @@ BsdfBuilder_addMirrorBSDF(
                 adaptedNormal);
     }
 
-    if (transWeight > 0.f) {
+    if (any(transWeight > 0.f)) {
         trans = (varying BsdfLobe * uniform)
             Arena_alloc(me.mTls->mArena, sizeof(varying MirrorTransmissionBsdfLobe));
         MirrorTransmissionBsdfLobe_init(
@@ -1066,7 +1066,7 @@ BsdfBuilder_addMicrofacetAnisotropicBSDF(
     const varying Vec3f adaptedNormal =
         Intersection_adaptNormal(asAnIntersection(*(me.mState)), bsdf.mN);
 
-    if (reflWeight > 0.f) {
+    if (any(reflWeight > 0.f)) {
         refl = (varying BsdfLobe * uniform)
             Arena_alloc(me.mTls->mArena, sizeof(varying AnisoCookTorranceBsdfLobe));
         AnisoCookTorranceBsdfLobe_init(
@@ -1085,7 +1085,7 @@ BsdfBuilder_addMicrofacetAnisotropicBSDF(
         const float avgReflectionRoughness =
             (bsdf.mRoughnessU + bsdf.mRoughnessV) * 0.5f;
 
-    if (transWeight > 0.0f) {
+    if (any(transWeight > 0.0f)) {
         trans = (varying BsdfLobe * uniform)
             Arena_alloc(me.mTls->mArena, sizeof(varying TransmissionCookTorranceBsdfLobe));
         float favg, favgInv;
@@ -1225,7 +1225,7 @@ BsdfBuilder_addMicrofacetIsotropicBSDF(
     const varying Vec3f adaptedNormal =
         Intersection_adaptNormal(asAnIntersection(*(me.mState)), bsdf.mN);
 
-    if (reflWeight > 0.f) {
+    if (any(reflWeight > 0.f)) {
         if (bsdf.mMicrofacetDistribution == MICROFACET_DISTRIBUTION_BECKMANN) {
             refl = (varying BsdfLobe * uniform)
                 Arena_alloc(me.mTls->mArena, sizeof(varying CookTorranceBsdfLobe));
@@ -1253,7 +1253,7 @@ BsdfBuilder_addMicrofacetIsotropicBSDF(
         }
     }
 
-    if (transWeight > 0.f) {
+    if (any(transWeight > 0.f)) {
         // Because the TransmissionCookTorranceBsdfLobe becomes unstable as the
         // relative IOR approaches 1.0 we create a mirror transmission lobe here.
         // Using any() here will likely introduce non-determinism and potentially

--- a/lib/rendering/shading/ispc/RampControl.ispc
+++ b/lib/rendering/shading/ispc/RampControl.ispc
@@ -264,8 +264,16 @@ evaluateMonotoneSlopes(varying ColorRampControl* uniform rampControl)
 }
 
 #define FIND_RAMP_SPAN_BODY                                 \
+    if (numEntries <= 0) {                                  \
+        leftIdx = -1;                                       \
+        rightIdx = -1;                                      \
+        return;                                             \
+    }                                                       \
     leftIdx = 0;                                            \
     rightIdx = numEntries - 1;                              \
+    if (numEntries == 1) {                                  \
+        return;                                             \
+    }                                                       \
                                                             \
     if (t < inputs[leftIdx]) {                              \
         leftIdx = -1;                                       \
@@ -554,61 +562,60 @@ blendAdjustment(const ColorRampControlSpace colorspace,
     result = leftOutput + weight * (rightOutput - leftOutput);                                  \
 
 #define EVAL_1D_COLOR_BODY                                                                      \
-    if (rampControl->mNumEntries == 0) {                                                        \
-        return sBlack;                                                                          \
-    }                                                                                           \
-                                                                                                \
-    int leftIdx, rightIdx;                                                                      \
-    findRampSpan(rampControl->mNumEntries, rampControl->mInputs, t, leftIdx, rightIdx);         \
-                                                                                                \
-    cif (leftIdx == -1) {                                                                       \
-        return rampControl->mOutputs[0];                                                        \
-    }                                                                                           \
-    cif (rightIdx == -1) {                                                                      \
-        return rampControl->mOutputs[rampControl->mNumEntries - 1];                             \
-    }                                                                                           \
-                                                                                                \
-    const float spanLength = rampControl->mInputs[rightIdx] - rampControl->mInputs[leftIdx];    \
-    cif (isZero(spanLength)) {                                                                  \
-        return rampControl->mOutputs[leftIdx];                                                  \
-    }                                                                                           \
-                                                                                                \
     Color result = sBlack;                                                                      \
-    float weight = 0.0f;                                                                        \
+    if (rampControl->mNumEntries != 0) {                                                        \
+        int leftIdx, rightIdx;                                                                  \
+        findRampSpan(rampControl->mNumEntries, rampControl->mInputs, t, leftIdx, rightIdx);     \
                                                                                                 \
-    t = (t - rampControl->mInputs[leftIdx]) / spanLength;                                       \
+        if (leftIdx == -1) {                                                                    \
+            result = rampControl->mOutputs[0];                                                  \
+        } else if (rightIdx == -1) {                                                            \
+            result = rampControl->mOutputs[rampControl->mNumEntries - 1];                       \
+        } else {                                                                                \
+            const float spanLength = rampControl->mInputs[rightIdx] - rampControl->mInputs[leftIdx];    \
+            if (!isZero(spanLength)) {                                                          \
+                float weight = 0.0f;                                                            \
+                t = (t - rampControl->mInputs[leftIdx]) / spanLength;                           \
                                                                                                 \
-    RampInterpolatorMode interpolator = rampControl->mInterpolators[leftIdx];                   \
+                RampInterpolatorMode interpolator = rampControl->mInterpolators[leftIdx];       \
                                                                                                 \
-    switch (interpolator) {                                                                     \
-    case RAMP_INTERPOLATOR_MODE_NONE:                                                           \
-        weight = 0.0f;                                                                          \
-        break;                                                                                  \
-    case RAMP_INTERPOLATOR_MODE_LINEAR:                                                         \
-        weight = t;                                                                             \
-        break;                                                                                  \
-    case RAMP_INTERPOLATOR_MODE_EXPONENTIAL_UP:                                                 \
-        weight = t * t;                                                                         \
-        break;                                                                                  \
-    case RAMP_INTERPOLATOR_MODE_EXPONENTIAL_DOWN:                                               \
-        weight = 1.0f - t;                                                                      \
-        weight = 1.0f - (weight * weight);                                                      \
-        break;                                                                                  \
-    case RAMP_INTERPOLATOR_MODE_SMOOTH:                                                         \
-        weight = sin(t *  sHalfPi);                                                             \
-        break;                                                                                  \
-    case RAMP_INTERPOLATOR_MODE_CATMULLROM:                                                     \
-    case RAMP_INTERPOLATOR_MODE_MONOTONECUBIC:                                                  \
-        result = computeCubicSplineValue(leftIdx, t, interpolator, rampControl);                \
-        return result;                                                                          \
+                switch (interpolator) {                                                         \
+                case RAMP_INTERPOLATOR_MODE_NONE:                                               \
+                    weight = 0.0f;                                                              \
+                    break;                                                                      \
+                case RAMP_INTERPOLATOR_MODE_LINEAR:                                             \
+                    weight = t;                                                                 \
+                    break;                                                                      \
+                case RAMP_INTERPOLATOR_MODE_EXPONENTIAL_UP:                                     \
+                    weight = t * t;                                                             \
+                    break;                                                                      \
+                case RAMP_INTERPOLATOR_MODE_EXPONENTIAL_DOWN:                                   \
+                    weight = 1.0f - t;                                                          \
+                    weight = 1.0f - (weight * weight);                                          \
+                    break;                                                                      \
+                case RAMP_INTERPOLATOR_MODE_SMOOTH:                                             \
+                    weight = sin(t *  sHalfPi);                                                 \
+                    break;                                                                      \
+                case RAMP_INTERPOLATOR_MODE_CATMULLROM:                                         \
+                case RAMP_INTERPOLATOR_MODE_MONOTONECUBIC:                                      \
+                    result = computeCubicSplineValue(leftIdx, t, interpolator, rampControl);    \
+                    break;                                                                      \
+                }                                                                               \
+                                                                                                \
+                if (interpolator != RAMP_INTERPOLATOR_MODE_CATMULLROM &&                        \
+                    interpolator != RAMP_INTERPOLATOR_MODE_MONOTONECUBIC) {                     \
+                    Color leftOutput = rampControl->mOutputs[leftIdx];                          \
+                    Color rightOutput = rampControl->mOutputs[rightIdx];                        \
+                    if (rampControl->mApplyHueBlendAdjustment) {                                \
+                        blendAdjustment(rampControl->mColorSpace, leftOutput, rightOutput);     \
+                    }                                                                           \
+                    result = leftOutput + weight * (rightOutput - leftOutput);                  \
+                }                                                                               \
+            } else {                                                                            \
+                result = rampControl->mOutputs[leftIdx];                                        \
+            }                                                                                   \
+        }                                                                                       \
     }                                                                                           \
-                                                                                                \
-    Color leftOutput = rampControl->mOutputs[leftIdx];                                          \
-    Color rightOutput = rampControl->mOutputs[rightIdx];                                        \
-    if (rampControl->mApplyHueBlendAdjustment) {                                                \
-        blendAdjustment(rampControl->mColorSpace, leftOutput, rightOutput);                     \
-    }                                                                                           \
-    result = leftOutput + weight * (rightOutput - leftOutput);                                  \
 
 varying float
 FloatRampControl_eval1D(varying float t,

--- a/lib/rendering/shading/ispc/bsdf/BsdfIridescence.ispc
+++ b/lib/rendering/shading/ispc/bsdf/BsdfIridescence.ispc
@@ -15,7 +15,11 @@
 inline varying float
 fitInRange(varying float value, const varying float oldMin, varying float oldMax, varying float newMin, varying float newMax)
 {
-    return ((newMax - newMin) * (value - oldMin) / (oldMax - oldMin)) + newMin;
+    const varying float range = oldMax - oldMin;
+    if (isZero(range)) {
+        return newMin;
+    }
+    return ((newMax - newMin) * (value - oldMin) / range) + newMin;
 }
 
 inline varying Color

--- a/tests/lib/rendering/pbr/TestBsdfOneSamplerv.cc
+++ b/tests/lib/rendering/pbr/TestBsdfOneSamplerv.cc
@@ -195,6 +195,28 @@ TestBsdfOneSamplerv::testIridescence()
                 (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
                 (sRoughness[i] > 0.1), TestBsdfSettings::BSDF_ONE_SAMPLERV);
         runTest(test, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
+
+        // Same hue for primary and secondary: spectrumDistance==0 triggers the
+        // fitInRange div-by-zero path.  (1,0,0) and (0.5,0,0) are different
+        // colors so isEqual() is false, but both map to hue=0.
+        IridescenceBsdfFactory sameHueFactory(sRoughness[i], 1.0f, ispc::SHADING_IRIDESCENCE_COLOR_USE_HUE_INTERPOLATION,
+                scene_rdl2::math::Color(1.f, 0.f, 0.f), scene_rdl2::math::Color(0.5f, 0.f, 0.f), false,
+                ispc::COLOR_RAMP_CONTROL_SPACE_RGB, size, positions, interpolators, colors,
+                2.f, 1.f, 1.f, 1.f);
+        TestBsdfSettings sameHueTest(sameHueFactory, frame, true, 0.002, 0.04,
+                (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
+                (sRoughness[i] > 0.1), TestBsdfSettings::BSDF_ONE_SAMPLERV);
+        runTest(sameHueTest, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
+
+        // RAMP mode
+        IridescenceBsdfFactory rampFactory(sRoughness[i], 1.0f, ispc::SHADING_IRIDESCENCE_COLOR_USE_RAMP,
+                scene_rdl2::math::Color(1.f, 0.f, 0.f), scene_rdl2::math::Color(1.f, 0.f, 1.f), false,
+                ispc::COLOR_RAMP_CONTROL_SPACE_RGB, size, positions, interpolators, colors,
+                2.f, 1.f, 1.f, 1.f);
+        TestBsdfSettings rampTest(rampFactory, frame, true, 0.002, 0.04,
+                (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
+                (sRoughness[i] > 0.1), TestBsdfSettings::BSDF_ONE_SAMPLERV);
+        runTest(rampTest, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
     }
 }
 

--- a/tests/lib/rendering/pbr/TestBsdfv.cc
+++ b/tests/lib/rendering/pbr/TestBsdfv.cc
@@ -207,6 +207,28 @@ TestBsdfv::testIridescence()
                 (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
                 (sRoughness[i] > 0.1), TestBsdfSettings::BSDFV);
         runTest(test, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
+
+        // Same hue for primary and secondary: spectrumDistance==0 triggers the
+        // fitInRange div-by-zero path.  (1,0,0) and (0.5,0,0) are different
+        // colors so isEqual() is false, but both map to hue=0.
+        IridescenceBsdfFactory sameHueFactory(sRoughness[i], 1.0f, ispc::SHADING_IRIDESCENCE_COLOR_USE_HUE_INTERPOLATION,
+                scene_rdl2::math::Color(1.f, 0.f, 0.f), scene_rdl2::math::Color(0.5f, 0.f, 0.f), false,
+                ispc::COLOR_RAMP_CONTROL_SPACE_RGB, size, positions, interpolators, colors,
+                2.f, 1.f, 1.f, 1.f);
+        TestBsdfSettings sameHueTest(sameHueFactory, frame, true, 0.002, 0.06,
+                (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
+                (sRoughness[i] > 0.1), TestBsdfSettings::BSDFV);
+        runTest(sameHueTest, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
+
+        // RAMP mode
+        IridescenceBsdfFactory rampFactory(sRoughness[i], 1.0f, ispc::SHADING_IRIDESCENCE_COLOR_USE_RAMP,
+                scene_rdl2::math::Color(1.f, 0.f, 0.f), scene_rdl2::math::Color(1.f, 0.f, 1.f), false,
+                ispc::COLOR_RAMP_CONTROL_SPACE_RGB, size, positions, interpolators, colors,
+                2.f, 1.f, 1.f, 1.f);
+        TestBsdfSettings rampTest(rampFactory, frame, true, 0.002, 0.06,
+                (sRoughness[i] > 0.1  &&  sRoughness[i] < 0.5),
+                (sRoughness[i] > 0.1), TestBsdfSettings::BSDFV);
+        runTest(rampTest, sViewAnglesTheta, 1, getSampleCount(sRoughness[i]));
     }
 }
 


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
<!-- major|minor|patch|build -->
build

## Issues/Tickets:
<!-- GitHub example: OpenMoonRay/openmoonray#1 -->
<!-- JIRA example: MOONRAY-0001 -->
MOONRAY-5822 MOONRAY-6057

## Release notes comment:
<!-- Provide a short meaningful description of the changes in this PR which will appear in the release notes. -->
<!-- example: Fixed a bug that caused a crash when rendering on certain hardware. -->
Fix a crash with iridescence in vector/xpu modes.

## Comments for the reviewer:
<!-- example: Removed unused code and fixed some typos -->
Fixes a crash path in iridescence/ramp evaluation by hardening ramp span lookup and avoiding divide-by-zero in iridescence range remapping.

Changes:

Add guards in ramp span lookup for empty/single-entry ramps and restructure 1D color ramp evaluation to avoid problematic early-return paths.
Prevent divide-by-zero in fitInRange() for iridescence (ISPC + C++) by handling oldMax == oldMin.

## Look or scene setup change:
<!-- If these changes may impact the look of existing scenes, please provide a description of the changes. -->
<!-- example: May cause subtle difference in fur/hair shading. -->
<!-- Leave blank if no expected look changes.  -->

## Special notes for production:
<!-- Any important notes to be called out to production regarding the release as a whole. -->
<!-- example: This Release marks a major change in the behavior of adaptive sampling! -->
<!-- Leave blank if no special notes.  -->

## Attention/Reviewers:
<!-- @user @user2 -->

## AI Assisted Development:
<!-- Assisted-by: Tool / Model -->
<!-- example:  Assisted-by: GitHub Copilot / Sonnet 4.6 -->
<!-- Leave blank if no AI assistance used.  -->

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.
<!-- Provide links if applicable -->
