### PR TITLE
Fixes geometry visibility flags in delta files

### DIFF
--- a/lib/rendering/rndr/RenderContext.cc
+++ b/lib/rendering/rndr/RenderContext.cc
@@ -693,8 +693,27 @@ RenderContext::checkGeometryChangesRequireReload()
     for (const auto& geomPair : changedGeoms) {
         scene_rdl2::rdl2::Geometry* geom = geomPair.first;
 
-        // Check if this geometry has attribute changes that require geometry reload
-        if (geom->attributeTreeChanged()) {
+        // A full reload is only required if a changed attribute actually needs
+        // the geometry to be regenerated/retessellated. Attributes are tagged
+        // to indicate when that is not necessary:
+        //   - FLAGS_CAN_SKIP_GEOM_RELOAD: change needs neither a reload nor a
+        //     BVH rebuild (e.g. ray_epsilon, a ray traversal tolerance).
+        //   - FLAGS_GEOM_RELOAD_BVH_ONLY: change needs a BVH rebuild but no
+        //     reload (e.g. the visibility flags, baked into the BVH ray mask).
+        // The BVH rebuild for the latter is handled by the normal incremental
+        // update path (the geometry stays in the changed-geometry list).
+        const scene_rdl2::rdl2::SceneClass& sceneClass = geom->getSceneClass();
+        for (auto attrIter = sceneClass.beginAttributes();
+             attrIter != sceneClass.endAttributes(); ++attrIter) {
+            const scene_rdl2::rdl2::Attribute* attribute = *attrIter;
+            if (!geom->hasChanged(attribute)) {
+                continue;
+            }
+            if (!attribute->updateRequiresGeomReload() ||
+                attribute->updateOnlyRequiresBVHRebuild()) {
+                continue;
+            }
+            // A reload-requiring attribute changed, so a reload is required.
             return true;
         }
     }


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
<!-- major|minor|patch|build -->
minor

## Issues/Tickets:
<!-- GitHub example: OpenMoonRay/openmoonray#1 -->
<!-- JIRA example: MOONRAY-0001 -->
MOONRAY-6062

## Release notes comment:
<!-- Provide a short meaningful description of the changes in this PR which will appear in the release notes. -->
<!-- example: Fixed a bug that caused a crash when rendering on certain hardware. -->
Fixes geometry visibility flags in delta files

## Comments for the reviewer:
<!-- example: Removed unused code and fixed some typos -->
Add FLAGS_GEOM_RELOAD_BVH_ONLY attribute flag

Introduce a new attribute flag for updates that require an acceleration
structure (BVH) rebuild but not a geometry regenerate/tessellate, and
tag the geometry visibility flags with it. Adds the
Attribute::updateOnlyRequiresBVHRebuild() helper. This lets the renderer
distinguish visibility-only changes (BVH rebuild, no full reload) from
ray-tolerance changes (FLAGS_CAN_SKIP_GEOM_RELOAD, neither) without a
hardcoded attribute name list.

Fixes bhv rebuild logic

Exclude geometry visibility flag attributes from full reload

checkGeometryChangesRequireReload now ignores changes to the visibility
flag attributes (visible_in_camera, visible_shadow, etc.) instead of
relying on attributeTreeChanged(), so toggling visibility no longer
triggers a full geometry reload.

Drive geometry reload check off attribute flags

Replace the hardcoded visibility attribute name list in
checkGeometryChangesRequireReload with flag-based checks:
updateRequiresGeomReload() (FLAGS_CAN_SKIP_GEOM_RELOAD) and the new
updateOnlyRequiresBVHRebuild() (FLAGS_GEOM_RELOAD_BVH_ONLY). The
visibility flags still stay on the changed-geometry list so the BVH is
rebuilt via the incremental update path, but no longer force a full
geometry reload.

Replay applied deltas when rebuilding RenderContext on full reload

When a delta changes a topology/visibility attribute that requires a full
reload, the GUI rebuilds the RenderContext from the base scene files only.
Previously the applied deltas were dropped, so the delta's attribute change
(e.g. visibility) and any earlier deltas were lost and the render did not
update.

Track applied deltas in a vector that survives the reload loop and replay
them into each freshly created context before initialize(), so they are
baked into the full scene load and geometry is regenerated with complete
primitive attribute tables (e.g. ref_P).

Applies to both moonray_gui and moonray_gui_v2.

## Look or scene setup change:
<!-- If these changes may impact the look of existing scenes, please provide a description of the changes. -->
<!-- example: May cause subtle difference in fur/hair shading. -->
<!-- Leave blank if no expected look changes.  -->

## Special notes for production:
<!-- Any important notes to be called out to production regarding the release as a whole. -->
<!-- example: This Release marks a major change in the behavior of adaptive sampling! -->
<!-- Leave blank if no special notes.  -->

## Attention/Reviewers:
<!-- @user @user2 -->

## AI Assisted Development:
<!-- Assisted-by: Tool / Model -->
<!-- example:  Assisted-by: GitHub Copilot / Sonnet 4.6 -->
<!-- Leave blank if no AI assistance used.  -->

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.
<!-- Provide links if applicable -->
