### PR TITLE
Use SceneVariables fatal_color when light and cookie light filter textures are missing instead of aborting the render

### DIFF
--- a/lib/rendering/pbr/core/Distribution.cc
+++ b/lib/rendering/pbr/core/Distribution.cc
@@ -807,7 +807,7 @@ ImageDistribution::init(const std::string &mapFilename,
 
     // Throw exception if 'in' is null
     if (in == nullptr) {
-        throw scene_rdl2::except::IoError("Image file \"" + mapFilename + "\" does not exist. Using black radiance");
+        throw scene_rdl2::except::IoError("Image file \"" + mapFilename + "\" does not exist.");
     }
 
     // Get ImageSpec

--- a/lib/rendering/pbr/light/CylinderLight.cc
+++ b/lib/rendering/pbr/light/CylinderLight.cc
@@ -395,6 +395,8 @@ CylinderLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const V
 
     if (mDistribution) {
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], 0, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/CylinderLight.ispc
+++ b/lib/rendering/pbr/light/CylinderLight.ispc
@@ -212,6 +212,8 @@ CylinderLight_eval(const uniform Light * uniform li, uniform ShadingTLState * un
         // TODO: Use proper filtering with ray differentials and mip-mapping.
         radiance = radiance * ImageDistribution_eval(light->mDistribution,
                 isect.uv.x, isect.uv.y, 0, light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/DiskLight.cc
+++ b/lib/rendering/pbr/light/DiskLight.cc
@@ -519,6 +519,8 @@ DiskLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Vec3f
 
     if (mDistribution) {
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], 0, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (pdf) {

--- a/lib/rendering/pbr/light/DiskLight.ispc
+++ b/lib/rendering/pbr/light/DiskLight.ispc
@@ -380,6 +380,8 @@ DiskLight_eval(const uniform Light * uniform li, uniform ShadingTLState * unifor
         // TODO: Use proper filtering with ray differentials and mip-mapping.
         radiance = radiance * ImageDistribution_eval(light->mDistribution,
                 isect.uv.x, isect.uv.y, 0, light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/DistantLight.cc
+++ b/lib/rendering/pbr/light/DistantLight.cc
@@ -441,6 +441,8 @@ DistantLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Ve
     Color radiance = mRadiance;
     if (mDistribution) {
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], mipLevel, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/DistantLight.ispc
+++ b/lib/rendering/pbr/light/DistantLight.ispc
@@ -225,6 +225,8 @@ DistantLight_eval(const uniform Light * uniform li, uniform ShadingTLState * uni
     if (light->mDistribution) {
         radiance = radiance * ImageDistribution_eval(light->mDistribution, isect.uv.x, isect.uv.y, mipLevel,
                                                      light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/EnvLight.cc
+++ b/lib/rendering/pbr/light/EnvLight.cc
@@ -307,6 +307,8 @@ EnvLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Vec3f 
     Color radiance = mRadiance;
     if (mDistribution) {
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], mipLevel, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/EnvLight.ispc
+++ b/lib/rendering/pbr/light/EnvLight.ispc
@@ -221,6 +221,8 @@ EnvLight_eval(const uniform Light * uniform li, uniform ShadingTLState * uniform
     if (light->mDistribution) {
         radiance = radiance * ImageDistribution_eval(light->mDistribution,
                 isect.uv.x, isect.uv.y, mipLevel, light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/Light.cc
+++ b/lib/rendering/pbr/light/Light.cc
@@ -49,6 +49,7 @@ Light::Light(const scene_rdl2::rdl2::Light* rdlLight) :
     mOrientation{zero, zero},
     mDirection(zero),
     mRadiance(zero),
+    mTextureFallbackColor(sWhite),
     mDistribution(nullptr),
     mDistributionMapping(Distribution2D::Mapping::NONE),
     mLabelId(-1),
@@ -138,6 +139,7 @@ Light::updateImageMap(Distribution2D::Mapping distributionMapping)
 
     delete mDistribution;
     mDistribution = nullptr;
+    mTextureFallbackColor = sWhite;
 
     const std::string & mapFilename = mRdlLight->get(scene_rdl2::rdl2::Light::sTextureKey);
     if (mapFilename.empty()) {
@@ -161,7 +163,17 @@ Light::updateImageMap(Distribution2D::Mapping distributionMapping)
             mRdlLight->get(scene_rdl2::rdl2::Light::sTextureMirrorUKey),
             mRdlLight->get(scene_rdl2::rdl2::Light::sTextureMirrorVKey),
             mRdlLight->get(scene_rdl2::rdl2::Light::sTextureBorderColorKey));
-    } catch (scene_rdl2::except::KeyError &e) {
+    } catch (except::IoError &e) {
+        // The texture was specified but failed to load. Log the error and fall
+        // back to the fatal color (set on the SceneVariables), leaving
+        // mDistribution null so the light uses its own native untextured
+        // sampling scheme. This matches the ImageMap shader's behavior of
+        // substituting the fatal color for a missing texture.
+        mRdlLight->error(e.what());
+        mTextureFallbackColor = mRdlLight->getSceneClass().getSceneContext()->
+            getSceneVariables().get(scene_rdl2::rdl2::SceneVariables::sFatalColor);
+        return true;
+    } catch (except::KeyError &e) {
         mRdlLight->error(e.what());
     }
 

--- a/lib/rendering/pbr/light/Light.hh
+++ b/lib/rendering/pbr/light/Light.hh
@@ -107,6 +107,11 @@ enum LightSidednessType
                                                                             \
     HUD_MEMBER(HUD_NAMESPACE(scene_rdl2::math, Color), mRadiance);                      \
                                                                             \
+    /* Color used in place of the texture when a texture was specified but */ \
+    /* failed to load. Defaults to white (a no-op multiplier); set to the */ \
+    /* fatal color on load failure so the missing texture is visible. */    \
+    HUD_MEMBER(HUD_NAMESPACE(scene_rdl2::math, Color), mTextureFallbackColor); \
+                                                                            \
     /* TODO: this should be a shared resource */                            \
     HUD_PTR(ImageDistribution *, mDistribution);                            \
     HUD_CPP_MEMBER(Distribution2D::Mapping, mDistributionMapping, 4);       \
@@ -150,6 +155,7 @@ enum LightSidednessType
     HUD_VALIDATE(Light, mOrientation);                  \
     HUD_VALIDATE(Light, mDirection);                    \
     HUD_VALIDATE(Light, mRadiance);                     \
+    HUD_VALIDATE(Light, mTextureFallbackColor);         \
     HUD_VALIDATE(Light, mDistribution);                 \
     HUD_VALIDATE(Light, mDistributionMapping);          \
     HUD_VALIDATE(Light, mLabelId);                      \

--- a/lib/rendering/pbr/light/RectLight.cc
+++ b/lib/rendering/pbr/light/RectLight.cc
@@ -504,6 +504,8 @@ RectLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Vec3f
 
     if (mDistribution) {
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], 0, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/RectLight.ispc
+++ b/lib/rendering/pbr/light/RectLight.ispc
@@ -345,6 +345,8 @@ RectLight_eval(const uniform Light * uniform li, uniform ShadingTLState * unifor
         // TODO: Use proper filtering with ray differentials and mip-mapping.
         radiance = radiance * ImageDistribution_eval(light->mDistribution,
                 isect.uv.x, isect.uv.y, 0, light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/SphereLight.cc
+++ b/lib/rendering/pbr/light/SphereLight.cc
@@ -428,6 +428,8 @@ SphereLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Vec
     if (mDistribution) {
         // Note: the distribution doesn't contribute to the pdf, since we ignore it when sampling
         radiance *= mDistribution->eval(isect.uv[0], isect.uv[1], 0, mTextureFilter);
+    } else {
+        radiance *= mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/SphereLight.ispc
+++ b/lib/rendering/pbr/light/SphereLight.ispc
@@ -340,6 +340,8 @@ SphereLight_eval(const uniform Light * uniform li, uniform ShadingTLState * unif
         // Note: the distribution doesn't contribute to the pdf, since we ignore it when sampling
         radiance = radiance * ImageDistribution_eval(light->mDistribution,
                 isect.uv.x, isect.uv.y, 0, light->mTextureFilter);
+    } else {
+        radiance = radiance * light->mTextureFallbackColor;
     }
 
     if (lightFilterList) {

--- a/lib/rendering/pbr/light/SpotLight.cc
+++ b/lib/rendering/pbr/light/SpotLight.cc
@@ -488,7 +488,8 @@ SpotLight::eval(mcrt_common::ThreadLocalState* tls, const Vec3f &wi, const Vec3f
     MNRY_ASSERT(mOn);
 
     // Apply texture if present
-    Color radiance = mDistribution ? mDistribution->eval(isect.uv.x, isect.uv.y, 0, mTextureFilter) : sWhite;
+    Color radiance = mDistribution ? mDistribution->eval(isect.uv.x, isect.uv.y, 0, mTextureFilter)
+                                   : mTextureFallbackColor;
 
     // Apply spotlight falloff function at intersection with focal plane
     Vec2f normalizedFocalCoords = 2.0f * isect.uv - Vec2f(1.0f, 1.0f);

--- a/lib/rendering/pbr/light/SpotLight.ispc
+++ b/lib/rendering/pbr/light/SpotLight.ispc
@@ -314,7 +314,7 @@ SpotLight_eval_uniform(const uniform Light * uniform li, uniform ShadingTLState 
     // Apply texture if present
     Color radiance = light->mDistribution ? ImageDistribution_eval(light->mDistribution,
                                                 isect.uv.x, isect.uv.y, 0, light->mTextureFilter)
-                                          : sWhite;
+                                          : light->mTextureFallbackColor;
 
     // Apply spotlight falloff function at intersection with focal plane
     Vec2f normalizedFocalCoords;

--- a/lib/rendering/pbr/lightfilter/CookieLightFilter_v2.cc
+++ b/lib/rendering/pbr/lightfilter/CookieLightFilter_v2.cc
@@ -41,6 +41,7 @@ HUD_VALIDATOR(CookieLightFilter_v2);
 
 CookieLightFilter_v2::CookieLightFilter_v2(const rdl2::LightFilter* rdlLightFilter) :
     LightFilter(rdlLightFilter),
+    mTextureFallbackColor(sWhite),
     mDistribution(nullptr)
 {
     if (mRdlLightFilter) {
@@ -307,9 +308,19 @@ CookieLightFilter_v2::update(const LightFilterMap& /*lightFilters*/,
 
     std::string textureFilename = mRdlLightFilter->get<rdl2::String>(sTextureKey);
 
+    delete mDistribution;
+    mDistribution = nullptr;
+    mTextureFallbackColor = sWhite;
+
+    if (textureFilename.empty()) {
+        // No texture specified: leave mDistribution null. The eval() sites fall
+        // back to mTextureFallbackColor (white), so the filter passes light
+        // through unchanged.
+        return;
+    }
+
     try {
         rdl2::Rgb gamma = mRdlLightFilter->get<rdl2::Rgb>(sGammaKey);
-        delete mDistribution;
         mDistribution = new ImageDistribution(textureFilename, 
                                               Distribution2D::Mapping::PLANAR,
                                               gamma,
@@ -327,6 +338,14 @@ CookieLightFilter_v2::update(const LightFilterMap& /*lightFilters*/,
                                               false,
                                               sWhite);
 
+    } catch (scene_rdl2::except::IoError &e) {
+        // The texture was specified but failed to load. Log the error and fall
+        // back to the fatal color (set on the SceneVariables), leaving
+        // mDistribution null so the eval() sites substitute the fatal color.
+        // This matches the untextured-fallback logic used by the lights.
+        mRdlLightFilter->error(e.what());
+        mTextureFallbackColor = mRdlLightFilter->getSceneClass().getSceneContext()->
+            getSceneVariables().get(rdl2::SceneVariables::sFatalColor);
     } catch (scene_rdl2::except::KeyError &e) {
         mRdlLightFilter->error(e.what());
     }
@@ -452,9 +471,14 @@ CookieLightFilter_v2::eval(const EvalData& data) const
         }
     }
 
-    // Lookup the map value using the displaced screen space position
-    Color mapValue = mDistribution->eval(st.x, st.y, 0,
-                         moonray::pbr::TextureFilterType::TEXTURE_FILTER_BILINEAR);
+    // Lookup the map value using the displaced screen space position. When the
+    // texture is missing, mDistribution is null and we fall back to the
+    // untextured color (white when unspecified, or the fatal color on a failed
+    // load), matching the untextured-fallback logic used by the lights.
+    Color mapValue = mDistribution ?
+        mDistribution->eval(st.x, st.y, 0,
+                         moonray::pbr::TextureFilterType::TEXTURE_FILTER_BILINEAR) :
+        mTextureFallbackColor;
 
     // Apply density scaling to allow partial light filtering
     mapValue = Color(1.f - mDensity) + mapValue * mDensity;

--- a/lib/rendering/pbr/lightfilter/CookieLightFilter_v2.ispc
+++ b/lib/rendering/pbr/lightfilter/CookieLightFilter_v2.ispc
@@ -145,9 +145,17 @@ CookieLightFilter_v2_eval(const uniform LightFilter * uniform lif,
         }
     }
 
-    *filterValue = ImageDistribution_eval(lf->mDistribution,
-                                          st.x, st.y, 0,
-                                          TEXTURE_FILTER_BILINEAR);
+    // Lookup the map value using the displaced screen space position. When the
+    // texture is missing, mDistribution is null and we fall back to the
+    // untextured color (white when unspecified, or the fatal color on a failed
+    // load), matching the untextured-fallback logic used by the lights.
+    if (lf->mDistribution != NULL) {
+        *filterValue = ImageDistribution_eval(lf->mDistribution,
+                                              st.x, st.y, 0,
+                                              TEXTURE_FILTER_BILINEAR);
+    } else {
+        *filterValue = lf->mTextureFallbackColor;
+    }
 
     filterValue->r = 1.f - lf->mDensity + filterValue->r * lf->mDensity;
     filterValue->g = 1.f - lf->mDensity + filterValue->g * lf->mDensity;

--- a/lib/rendering/pbr/lightfilter/LightFilter.hh
+++ b/lib/rendering/pbr/lightfilter/LightFilter.hh
@@ -193,6 +193,7 @@ enum CookieOutsideProjection
     HUD_MEMBER(int, mOutsideProjection);                                      \
     HUD_MEMBER(float, mDensity);                                              \
     HUD_MEMBER(bool, mInvert);                                                \
+    HUD_MEMBER(HUD_NAMESPACE(scene_rdl2::math, Color), mTextureFallbackColor);\
     HUD_PTR(ImageDistribution *, mDistribution)
 
 #define COOKIE_LIGHT_FILTER_V2_VALIDATION                                     \
@@ -210,6 +211,7 @@ enum CookieOutsideProjection
     HUD_VALIDATE(CookieLightFilter_v2, mOutsideProjection);                   \
     HUD_VALIDATE(CookieLightFilter_v2, mDensity);                             \
     HUD_VALIDATE(CookieLightFilter_v2, mInvert);                              \
+    HUD_VALIDATE(CookieLightFilter_v2, mTextureFallbackColor);                \
     HUD_VALIDATE(CookieLightFilter_v2, mDistribution);                        \
     HUD_END_VALIDATION
 


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
<!-- major|minor|patch|build -->
build

## Issues/Tickets:
<!-- GitHub example: OpenMoonRay/openmoonray#1 -->
<!-- JIRA example: MOONRAY-0001 -->
MOONRAY-5608

## Release notes comment:
<!-- Provide a short meaningful description of the changes in this PR which will appear in the release notes. -->
<!-- example: Fixed a bug that caused a crash when rendering on certain hardware. -->
Uses SceneVariables fatal_color when light and cookie light filter textures are missing instead of aborting the render


## Comments for the reviewer:
<!-- example: Removed unused code and fixed some typos -->

## Look or scene setup change:
<!-- If these changes may impact the look of existing scenes, please provide a description of the changes. -->
<!-- example: May cause subtle difference in fur/hair shading. -->
<!-- Leave blank if no expected look changes.  -->

## Special notes for production:
<!-- Any important notes to be called out to production regarding the release as a whole. -->
<!-- example: This Release marks a major change in the behavior of adaptive sampling! -->
<!-- Leave blank if no special notes.  -->

## Attention/Reviewers:
<!-- @user @user2 -->

## AI Assisted Development:
<!-- Assisted-by: Tool / Model -->
<!-- example:  Assisted-by: GitHub Copilot / Sonnet 4.6 -->
<!-- Leave blank if no AI assistance used.  -->

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.
<!-- Provide links if applicable -->
