### PR TITLE
Revert change to eye caustic BSDF

### DIFF
--- a/lib/rendering/shading/bsdf/BsdfEyeCaustic.h
+++ b/lib/rendering/shading/bsdf/BsdfEyeCaustic.h
@@ -81,7 +81,7 @@ public:
         const float cosThetaO = dot(mN, slice.getWo());
         if (cosThetaO <= 0.0f) return scene_rdl2::math::sBlack;
 
-        const float eyeCausticBrdfCosThetaI = scene_rdl2::math::min(dot(mFrame.getN(), wi), scene_rdl2::math::sOneMinusEpsilon);
+        const float eyeCausticBrdfCosThetaI = dot(mFrame.getN(), wi);
         if (eyeCausticBrdfCosThetaI <= 0.0f)      return scene_rdl2::math::sBlack;
 
         // Normalization Factor from [1]


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
<!-- major|minor|patch|build -->
build

## Issues/Tickets:
<!-- GitHub example: OpenMoonRay/openmoonray#1 -->
<!-- JIRA example: MOONRAY-0001 -->
MOONSHINE-2017

## Release notes comment:
<!-- Provide a short meaningful description of the changes in this PR which will appear in the release notes. -->
<!-- example: Fixed a bug that caused a crash when rendering on certain hardware. -->
Reverts bug fix from MOONSHINE-2017


## Comments for the reviewer:
<!-- example: Removed unused code and fixed some typos -->
This PR reverts a prior MOONSHINE-2017 change in the eye caustic BSDF by removing the clamp applied to the incident-
direction cosine term, restoring the previous raw  dot(N, wi)  behavior.

Changes:

Removed the  min(..., sOneMinusEpsilon)  clamp when computing  eyeCausticBrdfCosThetaI  in
EyeCausticBsdfLobe::eval() .


## Look or scene setup change:
<!-- If these changes may impact the look of existing scenes, please provide a description of the changes. -->
<!-- example: May cause subtle difference in fur/hair shading. -->
<!-- Leave blank if no expected look changes.  -->

## Special notes for production:
<!-- Any important notes to be called out to production regarding the release as a whole. -->
<!-- example: This Release marks a major change in the behavior of adaptive sampling! -->
<!-- Leave blank if no special notes.  -->

## Attention/Reviewers:
<!-- @user @user2 -->

## AI Assisted Development:
<!-- Assisted-by: Tool / Model -->
<!-- example:  Assisted-by: GitHub Copilot / Sonnet 4.6 -->
<!-- Leave blank if no AI assistance used.  -->

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.
<!-- Provide links if applicable -->
