### PR TITLE
Fix ARM half conversion in RenderOutputWriter

### DIFF
--- a/lib/rendering/rndr/RenderOutputWriter.cc
+++ b/lib/rendering/rndr/RenderOutputWriter.cc
@@ -1568,10 +1568,10 @@ float
 RenderOutputWriter::htof(const unsigned short h)
 {
 
-#if defined(__ARM_NEON__)   // TODO: Verify this
-	float output;
-	vst1q_f32(&output, vcvt_f32_f16(vld1_u16(&h)));
-	return output;
+#if defined(__ARM_NEON__)
+    __fp16 input;
+    std::memcpy(static_cast<void *>(&input), static_cast<const void *>(&h), sizeof(input));
+    return static_cast<float>(input);
 #else
     return _cvtsh_ss(h); // Convert half 16bit float to full 32bit float
 #endif
@@ -1583,10 +1583,11 @@ unsigned short
 RenderOutputWriter::ftoh(const float f)
 {
 
-#if defined(__ARM_NEON__)   // TODO: Verify this
-	__fp16 output;
-	vst1_f16(&output, vcvt_f16_f32(vld1q_f32(&f)));
-	return output;
+#if defined(__ARM_NEON__)
+    __fp16 h = static_cast<__fp16>(f);
+    unsigned short output;
+    std::memcpy(static_cast<void *>(&output), static_cast<const void *>(&h), sizeof(output));
+    return output;
 #else
     return _cvtss_sh(f, 0); // Convert full 32bit float to half 16bit float
                             // An immediate value controlling rounding using bits : 0=Nearest 


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
patch

## Issues/Tickets:
Render AOVs from Hou on Silicon macOS contained NaN without this fix, this fix got it working.

## Release notes comment:
Fixed scalar half-float conversion in RenderOutputWriter on Apple Silicon.

## Comments for the reviewer:
The previous ARM/NEON implementation used vector load/store intrinsics with scalar addresses. This change converts through scalar `__fp16` values and uses `std::memcpy` to preserve the exact 16-bit representation.

This is one part of an earlier Apple Silicon native AOV investigation:
https://github.com/OpenMoonRay/hdMoonray/compare/c7bbd30109884fcaf4c2536c1849dd54208cb0c1...4234f273fa5f3bb36cfd4a3fa5dff39da1cdd69d

The separate hdMoonray render-buffer allocation change from that investigation is intentionally excluded from this PR. This PR retains only the independent low-level Apple Silicon half-conversion correction.

## Look or scene setup change:
No scene setup changes are required. On Apple Silicon, outputs previously affected by incorrect half-float conversion may now contain the intended values.

## Special notes for production:
The changed code path is limited to ARM/NEON builds. The existing non-ARM conversion path is unchanged.

## Attention/Reviewers:

## AI Assisted Development:
Assisted-by: OpenAI Codex / GPT-5.6

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.

No documentation, unit-test, or RATS changes are included in this narrowly scoped correction.