### PR TITLE
Use std atomic in Metal GPU accelerator map

### DIFF
--- a/lib/rendering/rt/gpu/metal/MetalGPUAccelerator.h
+++ b/lib/rendering/rt/gpu/metal/MetalGPUAccelerator.h
@@ -17,13 +17,14 @@
 #include <scene_rdl2/scene/rdl2/RootShader.h>
 
 #include <tbb/concurrent_unordered_map.h>
+#include <atomic>
 
 namespace moonray {
 namespace rt {
 
 // Also in EmbreeAccelerator.cc
 typedef tbb::concurrent_unordered_map<std::shared_ptr<geom::SharedPrimitive>,
-        tbb::atomic<MetalGPUPrimitiveGroup*>, geom::SharedPtrHash> SharedGroupMap;
+        std::atomic<MetalGPUPrimitiveGroup*>, geom::SharedPtrHash> SharedGroupMap;
 
 
 class MetalGPUAccelerator


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
build

## Issues/Tickets:

## Release notes comment:
Updated the Metal GPU accelerator map to use the standard C++ atomic implementation.

## Comments for the reviewer:
This is the isolated `MetalGPUAccelerator` change extracted from the historical OpenMoonRay platform-alignment work.

The map value type now uses `std::atomic<MetalGPUPrimitiveGroup*>` instead of `tbb::atomic<MetalGPUPrimitiveGroup*>`, providing compatibility with newer oneTBB versions where the legacy TBB atomic type is no longer available.

The required `<atomic>` header is included explicitly.

No other Metal, GPU, rendering, dependency, or submodule changes are included.

## Look or scene setup change:
No expected look or scene setup changes.

## Special notes for production:
This is a build-compatibility change for the Metal GPU accelerator and newer oneTBB versions.

## Attention/Reviewers:

## AI Assisted Development:
Assisted-by: OpenAI Codex / GPT-5.6

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.

No documentation, unit-test, or RATS changes are included for this isolated type replacement.