### PR TITLE
Remove obsolete AppleClang alignof warning suppression

### DIFF
--- a/cmake/MoonrayCompileOptions.cmake
+++ b/cmake/MoonrayCompileOptions.cmake
@@ -49,7 +49,6 @@ function(${PROJECT_NAME}_cxx_compile_options target)
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang)
         target_compile_options(${target}
             PUBLIC
-                -Wno-gnu-alignof-expression
         )
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL Intel)
         target_compile_options(${target}


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
build

## Issues/Tickets:
OpenMoonRay/openmoonray#276

Related changes tracked separately:
- OpenMoonRay/openmoonray#274
- OpenMoonRay/moonray#36

## Release notes comment:
Removed an obsolete AppleClang warning suppression for compatibility with newer macOS compiler toolchains.

## Comments for the reviewer:
This is a minimal extraction from the Houdini 22 macOS validation branch.

Current upstream already contains the relevant USD and oneTBB source compatibility. The only remaining MoonRay change is removal of the obsolete `-Wno-gnu-alignof-expression` AppleClang option.

The Metal atomic and Apple Silicon half-conversion changes are intentionally excluded because they already have separate focused PRs.

Umbrella validation PR:
https://github.com/OpenMoonRay/openmoonray/pull/276

Houdini 22 build notes:
https://github.com/gripeyes/openmoonray/blob/test/houdini22-clean-build/building/macOS/Houdini22_build_notes.md

## Look or scene setup change:


## Special notes for production:


## Attention/Reviewers:


## AI Assisted Development:
Assisted-by: OpenAI Codex / GPT-5.6

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.
<!-- Provide links if applicable -->